### PR TITLE
12 fix runtime zombie processes

### DIFF
--- a/runtime/deploy.sh
+++ b/runtime/deploy.sh
@@ -7,7 +7,7 @@ set -o xtrace
 
 readonly PROJECT_NAME=runtime
 readonly TARGET_ARCH=armv7-unknown-linux-gnueabihf
-readonly SOURCE_PATH=target/${TARGET_ARCH}/release/${PROJECT_NAME}
+readonly SOURCE_PATH=../target/${TARGET_ARCH}/release/${PROJECT_NAME}
 # readonly SOURCE_SERVICE=${PROJECT_NAME}.service
 
 # If necessary, change the following values.


### PR DESCRIPTION
Closes #12.

Wait on child processes after they have been killed in `stop_processes`.
The wait() syscall returns the exit code, and that means that the children can be reaped. Sounds grim? Sure, but it works well now ;)