### PR TITLE
Fix deadlock on Cockpit-backend disconnect from Runtime

### DIFF
--- a/runtime/src/main.rs
+++ b/runtime/src/main.rs
@@ -77,6 +77,13 @@ impl State {
         }
     }
 }
+
+impl Drop for State {
+    fn drop(&mut self) {
+        self.disable();
+    }
+}
+
 fn main() -> io::Result<()> {
     let settings = settings().unwrap();
     let address = format!("0.0.0.0:{}", settings.port());


### PR DESCRIPTION
Implemented Drop for State to make sure we kill linkage lib and carburator processes