### PR TITLE
Runtime: Add config entries for node_path and carburetor_path

### DIFF
--- a/common/src/config.rs
+++ b/common/src/config.rs
@@ -58,6 +58,8 @@ impl LinkageLib {
 pub struct Runtime {
     port: AddressPort,
     linkage_lib_entry_point: String,
+    node_path: String,
+    carburetor_path: String,
 }
 
 impl Runtime {
@@ -67,6 +69,14 @@ impl Runtime {
 
     pub fn linkage_lib_entry_point(&self) -> &String {
         &self.linkage_lib_entry_point
+    }
+
+    pub fn node_path(&self) -> &String {
+        &self.node_path
+    }
+
+    pub fn carburetor_path(&self) -> &String {
+        &self.carburetor_path
     }
 }
 

--- a/config.default.toml
+++ b/config.default.toml
@@ -4,11 +4,13 @@ address = { host = "0.0.0.0", port = 12362 }
 [runtime]
 port = 8009
 linkage_lib_entry_point = "PLACEHOLDER"
+node_path = "NODE_PATH"
+carburetor_path = "CARBURETOR_PATH"
 
 [carburetor]
 port = 48862
 
 [cockpit_backend]
-port = 3013
+port = 3012
 runtime_address = { host = "0.0.0.0", port = 8009 }
 linkage_lib_address = { host = "0.0.0.0", port = 12362 }


### PR DESCRIPTION
This will make it possible to run all processes on the Pi and on your local machine. This is needed because the executables are stored in different locations on different machines.