### PR TITLE
Cockpit-backend: Refactor into multiple files

### DIFF
--- a/runtime/src/main.rs
+++ b/runtime/src/main.rs
@@ -1,84 +1,15 @@
-use std::io::{self, Read, Write};
-use std::net::{TcpListener, TcpStream};
-use std::process::{Child, Command, Stdio};
-use std::sync::mpsc::{Receiver, Sender};
+mod processes;
+mod state;
 
-use common::config;
-use simple_signal::Signal;
+use state::State;
+use std::io::{self, Read};
+use std::net::TcpListener;
 
-type MessageBytes = [u8; 8];
-
-const RUNTIME_TX_ENABLED: MessageBytes = [0x00, 0, 0, 0, 0, 0, 0, 0];
-const RUNTIME_RX_DISABLED: MessageBytes = [0x01, 0, 0, 0, 0, 0, 0, 0];
-
-enum LinkageState {
-    Enabled(Vec<Child>),
-    Disabled,
-}
-
-struct State {
-    backend: TcpStream,
-    state: LinkageState,
-    alrm_signal_receiver: Receiver<()>,
-}
-
-impl State {
-    fn new(backend_stream: TcpStream) -> Self {
-        let (alrm_signal_sender, alrm_signal_receiver) = std::sync::mpsc::channel();
-        handle_alrm_signal(alrm_signal_sender);
-
-        Self {
-            backend: backend_stream,
-            state: LinkageState::Disabled,
-            alrm_signal_receiver,
-        }
-    }
-}
-
-impl State {
-    fn enable(&mut self, config: &config::Runtime) {
-        eprintln!("Enabling Linakge... ");
-        match self.state {
-            LinkageState::Disabled => {
-                let children = start_processes(config);
-
-                self.alrm_signal_receiver.recv().unwrap();
-
-                self.state = LinkageState::Enabled(children);
-                eprintln!("Linkage Enabled.");
-            }
-            _ => eprintln!("Already enabled, doing nothing."),
-        }
-
-        self.backend.write(&RUNTIME_TX_ENABLED).unwrap();
-    }
-
-    fn disable(&mut self) -> io::Result<()> {
-        eprintln!("Disabling Linkage... ");
-        match &mut self.state {
-            LinkageState::Enabled(children) => {
-                stop_processes(children)?;
-                self.state = LinkageState::Disabled;
-                eprintln!("Linkage Disabled.");
-            }
-            _ => eprintln!("Already disabled, doing nothing."),
-        }
-
-        self.backend.write(&RUNTIME_RX_DISABLED)?;
-
-        Ok(())
-    }
-}
-
-impl Drop for State {
-    fn drop(&mut self) {
-        self.disable()
-            .expect("should shut down child processes on drop");
-    }
-}
+pub(crate) type MessageBytes = [u8; 8];
 
 fn main() -> io::Result<()> {
     let config = common::config::config().expect("should get config");
+
     let address = format!("0.0.0.0:{}", config.runtime().port());
     let listener = TcpListener::bind(address).expect("address should be valid");
     eprintln!("Started Listening on {}", listener.local_addr()?);
@@ -105,42 +36,6 @@ fn main() -> io::Result<()> {
 
     eprintln!("Connection closed.");
     state.disable()?;
-
-    Ok(())
-}
-
-fn handle_alrm_signal(sender: Sender<()>) {
-    simple_signal::set_handler(&[Signal::Alrm], {
-        move |signals| {
-            eprintln!("Caught Signal: {signals:?}");
-            sender.send(()).expect("should be a valid channel");
-        }
-    });
-}
-
-fn start_processes(config: &config::Runtime) -> Vec<Child> {
-    eprintln!("Starting Linkage");
-
-    let carburetor_process = Command::new(config.carburetor_path())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn()
-        .expect("failed to execute carburetor");
-
-    let linkage_process = Command::new(config.node_path())
-        .current_dir("/")
-        .arg(config.linkage_lib_entry_point())
-        .spawn()
-        .expect("failed to execute linkage");
-
-    vec![carburetor_process, linkage_process]
-}
-
-fn stop_processes(children: &mut Vec<Child>) -> io::Result<()> {
-    for child in children {
-        child.kill()?;
-        child.wait()?;
-    }
 
     Ok(())
 }

--- a/runtime/src/processes.rs
+++ b/runtime/src/processes.rs
@@ -1,0 +1,44 @@
+use std::{
+    io,
+    process::{Child, Command, Stdio},
+    sync::mpsc::Sender,
+};
+
+use common::config;
+use simple_signal::Signal;
+
+pub(crate) fn handle_alrm_signal(sender: Sender<()>) {
+    simple_signal::set_handler(&[Signal::Alrm], {
+        move |signals| {
+            eprintln!("Caught Signal: {signals:?}");
+            sender.send(()).expect("should be a valid channel");
+        }
+    });
+}
+
+pub(crate) fn start_processes(config: &config::Runtime) -> Vec<Child> {
+    eprintln!("Starting Linkage");
+
+    let carburetor_process = Command::new(config.carburetor_path())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to execute carburetor");
+
+    let linkage_process = Command::new(config.node_path())
+        .current_dir("/")
+        .arg(config.linkage_lib_entry_point())
+        .spawn()
+        .expect("failed to execute linkage");
+
+    vec![carburetor_process, linkage_process]
+}
+
+pub(crate) fn stop_processes(children: &mut Vec<Child>) -> io::Result<()> {
+    for child in children {
+        child.kill()?;
+        child.wait()?;
+    }
+
+    Ok(())
+}

--- a/runtime/src/state.rs
+++ b/runtime/src/state.rs
@@ -1,0 +1,84 @@
+use crate::{processes, MessageBytes};
+
+use common::config;
+use std::{
+    io::{self, Write},
+    net::TcpStream,
+    process::Child,
+    sync::mpsc::Receiver,
+};
+
+const RUNTIME_TX_ENABLED: MessageBytes = [0x00, 0, 0, 0, 0, 0, 0, 0];
+const RUNTIME_RX_DISABLED: MessageBytes = [0x01, 0, 0, 0, 0, 0, 0, 0];
+
+pub(crate) enum LinkageState {
+    Enabled(Vec<Child>),
+    Disabled,
+}
+
+pub(crate) struct State {
+    backend: TcpStream,
+    state: LinkageState,
+    alrm_signal_receiver: Receiver<()>,
+}
+
+impl State {
+    pub(crate) fn new(backend_stream: TcpStream) -> Self {
+        let (alrm_signal_sender, alrm_signal_receiver) = std::sync::mpsc::channel();
+        processes::handle_alrm_signal(alrm_signal_sender);
+
+        Self {
+            backend: backend_stream,
+            state: LinkageState::Disabled,
+            alrm_signal_receiver,
+        }
+    }
+}
+
+impl State {
+    pub(crate) fn enable(&mut self, config: &config::Runtime) {
+        eprintln!("Enabling Linakge... ");
+        match self.state {
+            LinkageState::Disabled => {
+                let children = processes::start_processes(config);
+
+                self.alrm_signal_receiver
+                    .recv()
+                    .expect("should receive alrm signal");
+
+                self.state = LinkageState::Enabled(children);
+                eprintln!("Linkage Enabled.");
+            }
+            _ => eprintln!("Already enabled, doing nothing."),
+        }
+
+        self.backend
+            .write(&RUNTIME_TX_ENABLED)
+            .expect("should send the ENABLED message to cockpit-backend");
+    }
+
+    pub(crate) fn disable(&mut self) -> io::Result<()> {
+        eprintln!("Disabling Linkage... ");
+        match &mut self.state {
+            LinkageState::Enabled(children) => {
+                processes::stop_processes(children)?;
+                self.state = LinkageState::Disabled;
+                eprintln!("Linkage Disabled.");
+            }
+            _ => eprintln!("Already disabled, doing nothing."),
+        }
+
+        self.backend
+            .write(&RUNTIME_RX_DISABLED)
+            .expect("should send the DISABLED message to cockpit-backend");
+
+        Ok(())
+    }
+}
+
+impl Drop for State {
+    fn drop(&mut self) {
+        self.disable()
+            .expect("should shut down child processes on drop");
+    }
+}


### PR DESCRIPTION
This makes the code a lot more readable. Also closes #21.