### PR TITLE
Runtime: Allow multiple Cockpit-Backend connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,6 +192,73 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf2b3e8478797446514c91ef04bafcb59faba183e621ad488df88983cc14128c"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
+dependencies = [
+ "autocfg",
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1cfb3ea8a53f37c40dea2c7bedcbd88bdfae54f5e2175d6ecaff1c988353add"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -496,6 +563,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
+name = "memoffset"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -771,6 +847,7 @@ name = "runtime"
 version = "0.1.0"
 dependencies = [
  "common",
+ "crossbeam",
  "simple-signal",
 ]
 
@@ -789,6 +866,12 @@ name = "ryu"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"

--- a/cockpit/backend/src/main.rs
+++ b/cockpit/backend/src/main.rs
@@ -10,6 +10,8 @@ fn main() -> io::Result<()> {
         let runtime_stream =
             TcpStream::connect(config.cockpit_backend().runtime_address().to_string())
                 .expect("should connect to runtime");
+        // FIXME: We still crash when Runtime is not found or isn't running. see issue #24
+
         eprintln!(
             "Connected to Runtime on address {}.",
             runtime_stream.local_addr().unwrap()

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -7,3 +7,4 @@ authors.workspace = true
 [dependencies]
 simple-signal = "1.1.1"
 common = { path = "../common" }
+crossbeam = "0.8.2"

--- a/runtime/src/main.rs
+++ b/runtime/src/main.rs
@@ -14,28 +14,33 @@ fn main() -> io::Result<()> {
     let listener = TcpListener::bind(address).expect("address should be valid");
     eprintln!("Started Listening on {}", listener.local_addr()?);
 
-    let (backend, _) = listener.accept()?;
-    let peer = backend.peer_addr()?;
-    eprintln!("Connection established with {peer}");
+    let (alrm_signal_sender, alrm_signal_receiver) = crossbeam::channel::unbounded();
+    processes::handle_alrm_signal(alrm_signal_sender);
 
-    let mut state = State::new(backend.try_clone()?);
+    for backend in listener.incoming() {
+        let backend = backend?;
 
-    let mut buffer = MessageBytes::default();
-    loop {
-        if backend.try_clone()?.read_exact(&mut buffer).is_err() {
-            break;
-        };
+        let peer = backend.peer_addr()?;
+        eprintln!("Connection established with {peer}");
 
-        eprintln!("Received message: {buffer:?}");
-        match buffer[0] {
-            0x00 => state.enable(config.runtime()),
-            0x01 => state.disable()?,
-            _ => eprintln!("Unknown message: {buffer:?}"),
+        let mut state = State::new(backend.try_clone()?, alrm_signal_receiver.clone());
+
+        let mut buffer = MessageBytes::default();
+        loop {
+            if backend.try_clone()?.read_exact(&mut buffer).is_err() {
+                break;
+            };
+
+            eprintln!("Received message: {buffer:?}");
+            match buffer[0] {
+                0x00 => state.enable(config.runtime()),
+                0x01 => state.disable()?,
+                _ => eprintln!("Unknown message: {buffer:?}"),
+            }
         }
-    }
 
-    eprintln!("Connection closed.");
-    state.disable()?;
+        eprintln!("Connection with {peer} closed.");
+    }
 
     Ok(())
 }

--- a/runtime/src/processes.rs
+++ b/runtime/src/processes.rs
@@ -1,24 +1,25 @@
 use std::{
     io,
     process::{Child, Command, Stdio},
-    sync::mpsc::Sender,
 };
 
 use common::config;
 use simple_signal::Signal;
 
-pub(crate) fn handle_alrm_signal(sender: Sender<()>) {
+pub(crate) fn handle_alrm_signal(sender: crossbeam::channel::Sender<()>) {
+    eprintln!("Start listening for ALRM Signal");
+
     simple_signal::set_handler(&[Signal::Alrm], {
-        move |signals| {
-            eprintln!("Caught Signal: {signals:?}");
-            sender.send(()).expect("should be a valid channel");
+        move |_signals| {
+            eprintln!("Caught ALRM signal");
+            sender
+                .send(())
+                .expect("failed to send ALRM signal over channel");
         }
     });
 }
 
 pub(crate) fn start_processes(config: &config::Runtime) -> Vec<Child> {
-    eprintln!("Starting Linkage");
-
     let carburetor_process = Command::new(config.carburetor_path())
         .stdout(Stdio::null())
         .stderr(Stdio::null())

--- a/runtime/src/state.rs
+++ b/runtime/src/state.rs
@@ -5,11 +5,10 @@ use std::{
     io::{self, Write},
     net::TcpStream,
     process::Child,
-    sync::mpsc::Receiver,
 };
 
 const RUNTIME_TX_ENABLED: MessageBytes = [0x00, 0, 0, 0, 0, 0, 0, 0];
-const RUNTIME_RX_DISABLED: MessageBytes = [0x01, 0, 0, 0, 0, 0, 0, 0];
+const RUNTIME_TX_DISABLED: MessageBytes = [0x01, 0, 0, 0, 0, 0, 0, 0];
 
 pub(crate) enum LinkageState {
     Enabled(Vec<Child>),
@@ -19,14 +18,14 @@ pub(crate) enum LinkageState {
 pub(crate) struct State {
     backend: TcpStream,
     state: LinkageState,
-    alrm_signal_receiver: Receiver<()>,
+    alrm_signal_receiver: crossbeam::channel::Receiver<()>,
 }
 
 impl State {
-    pub(crate) fn new(backend_stream: TcpStream) -> Self {
-        let (alrm_signal_sender, alrm_signal_receiver) = std::sync::mpsc::channel();
-        processes::handle_alrm_signal(alrm_signal_sender);
-
+    pub(crate) fn new(
+        backend_stream: TcpStream,
+        alrm_signal_receiver: crossbeam::channel::Receiver<()>,
+    ) -> Self {
         Self {
             backend: backend_stream,
             state: LinkageState::Disabled,
@@ -37,7 +36,7 @@ impl State {
 
 impl State {
     pub(crate) fn enable(&mut self, config: &config::Runtime) {
-        eprintln!("Enabling Linakge... ");
+        eprint!("Enabling Linakge... ");
         match self.state {
             LinkageState::Disabled => {
                 let children = processes::start_processes(config);
@@ -58,7 +57,7 @@ impl State {
     }
 
     pub(crate) fn disable(&mut self) -> io::Result<()> {
-        eprintln!("Disabling Linkage... ");
+        eprint!("Disabling Linkage... ");
         match &mut self.state {
             LinkageState::Enabled(children) => {
                 processes::stop_processes(children)?;
@@ -69,7 +68,7 @@ impl State {
         }
 
         self.backend
-            .write(&RUNTIME_RX_DISABLED)
+            .write(&RUNTIME_TX_DISABLED)
             .expect("should send the DISABLED message to cockpit-backend");
 
         Ok(())


### PR DESCRIPTION
Previously, when you reconnected with runtime from Cockpit-Backend, Runtime would close as only one connection was being listened on. When that connection was closed, the program would exit.

I'm using the crossbeam crate to be able to use a MPMC model. This way we can always have a single ALRM signal listener in the program. If you have a better suggestion that doen not use another crate your welcome to give feedback, but I'm not sure how to propperly do it the standard Rust way.