### PR TITLE
Cockpit: Add timeout for reading Gauge TcpStream

### DIFF
--- a/cockpit/src-tauri/src/gauge.rs
+++ b/cockpit/src-tauri/src/gauge.rs
@@ -1,3 +1,4 @@
+use std::time::Duration;
 use std::{
     io::{BufRead, BufReader},
     net::TcpStream,
@@ -13,13 +14,26 @@ const EVENT_RECEIVED_SYSTEM_INFO: &str = "received_system_info";
 pub fn start_gauge_connection<R: tauri::Runtime>(app: tauri::AppHandle<R>) -> Result<(), String> {
     thread::spawn(move || match TcpStream::connect("raspberrypi.local:4226") {
         Ok(stream) => {
+            stream
+                .set_read_timeout(Some(Duration::from_millis(2000)))
+                .unwrap();
+
             let mut buf_reader = BufReader::new(stream);
 
             let mut json_string = String::new();
-            while buf_reader.read_line(&mut json_string).is_ok() {
-                let system_info: SystemInfo = serde_json::from_str(json_string.trim()).unwrap();
-                on_receive_system_info(&app, system_info).unwrap();
-                json_string.clear()
+
+            loop {
+                match buf_reader.read_line(&mut json_string) {
+                    Ok(_) => {
+                        let system_info: SystemInfo =
+                            serde_json::from_str(json_string.trim()).unwrap();
+                        on_receive_system_info(&app, system_info).unwrap();
+                        json_string.clear();
+                    }
+                    Err(error) => {
+                        log::error!("Failed to read message from Gauge TcpStream: {error}")
+                    }
+                }
             }
         }
         Err(error) => {


### PR DESCRIPTION
This would block when it couldn't talk to Gauge, e.g. when the Pi is turned off while connected to Cockpit.