### PR TITLE
Add dropdown to select logger level in Cockpit

### DIFF
--- a/cockpit/src/lib/components/logger/LoggerOutput.svelte
+++ b/cockpit/src/lib/components/logger/LoggerOutput.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { LogLevel, logLevelLabel, type Log } from '$lib/process-logger';
 	import { tick } from 'svelte';
+	import { loggerState } from '$lib/logger';
 
 	export let stream: ReadableStream<Log> | undefined;
 	export let maxScrollback = 500;
@@ -57,17 +58,19 @@
 <div class="logger-output" bind:this={loggerElement}>
 	{#if stream}
 		{#each logs as log}
-			<div
-				class="line"
-				class:level-error={log.level === LogLevel.ERROR}
-				class:level-warn={log.level === LogLevel.WARN}
-				class:level-info={log.level === LogLevel.INFO}
-				class:level-debug={log.level === LogLevel.DEBUG}>
-				<span title={`${log.file}:${log.line}`}>
-					[{log.date.toLocaleTimeString()}
-					{logLevelLabel(log.level)}] {log.msg}
-				</span>
-			</div>
+			{#if log.level <= $loggerState.level}
+				<div
+					class="line"
+					class:level-error={log.level === LogLevel.ERROR}
+					class:level-warn={log.level === LogLevel.WARN}
+					class:level-info={log.level === LogLevel.INFO}
+					class:level-debug={log.level === LogLevel.DEBUG}>
+					<span title={`${log.file}:${log.line}`}>
+						[{log.date.toLocaleTimeString()}
+						{logLevelLabel(log.level)}] {log.msg}
+					</span>
+				</div>
+			{/if}
 		{/each}
 	{:else}
 		<div class="logger-closed-message">

--- a/cockpit/src/lib/components/logger/LoggerOutput.svelte
+++ b/cockpit/src/lib/components/logger/LoggerOutput.svelte
@@ -30,15 +30,15 @@
 			if (logs.length > maxScrollback) logs.shift();
 			logs = logs;
 		}
-		reader.cancel();
-		stream?.cancel();
+		await reader.cancel();
+		await stream?.cancel();
 	}
 
 	async function scrollToBottom() {
 		if (!loggerElement) return;
 
 		// BUG: When we press the Enable/Disable button this won't update
-		//	 	as the scrollheight is 0 because we just made the other log invisible.
+		// 		as the scrollheight is 0 because we just made the other log invisible.
 		const isScrolledToBottom =
 			loggerElement.scrollHeight - loggerElement.clientHeight <=
 			loggerElement.scrollTop + 32;
@@ -62,8 +62,7 @@
 				class:level-error={log.level === LogLevel.ERROR}
 				class:level-warn={log.level === LogLevel.WARN}
 				class:level-info={log.level === LogLevel.INFO}
-				class:level-debug={log.level === LogLevel.DEBUG}
-				class:level-trace={log.level === LogLevel.TRACE}>
+				class:level-debug={log.level === LogLevel.DEBUG}>
 				<span title={`${log.file}:${log.line}`}>
 					[{log.date.toLocaleTimeString()}
 					{logLevelLabel(log.level)}] {log.msg}
@@ -158,5 +157,4 @@
 	);
 	@include log-level('.level-info', $c-primary, $c-background, $c-gray-2);
 	@include log-level('.level-debug', $c-secondary, $c-background, $c-gray-2);
-	@include log-level('.level-trace', $c-secondary, $c-background, $c-gray-2);
 </style>

--- a/cockpit/src/lib/components/logger/Loggers.svelte
+++ b/cockpit/src/lib/components/logger/Loggers.svelte
@@ -16,10 +16,18 @@
 			</select>
 
 			<select bind:value={$loggerState.level}>
-				<option value={LogLevel.ERROR}>{logLevelLabel(LogLevel.ERROR)}</option>
-				<option value={LogLevel.WARN}>{logLevelLabel(LogLevel.WARN)}</option>
-				<option value={LogLevel.INFO}>{logLevelLabel(LogLevel.INFO)}</option>
-				<option value={LogLevel.DEBUG}>{logLevelLabel(LogLevel.DEBUG)}</option>
+				<option value={LogLevel.ERROR}>
+					{logLevelLabel(LogLevel.ERROR)}
+				</option>
+				<option value={LogLevel.WARN}>
+					{logLevelLabel(LogLevel.WARN)}
+				</option>
+				<option value={LogLevel.INFO}>
+					{logLevelLabel(LogLevel.INFO)}
+				</option>
+				<option value={LogLevel.DEBUG}>
+					{logLevelLabel(LogLevel.DEBUG)}
+				</option>
 			</select>
 		</div>
 	</div>

--- a/cockpit/src/lib/components/logger/Loggers.svelte
+++ b/cockpit/src/lib/components/logger/Loggers.svelte
@@ -12,7 +12,7 @@
 			<select bind:value={$loggerState.selectedTabId}>
 				{#each Object.keys(tabs) as tabId}
 					<option value={tabId}>{tabs[tabId].name}</option>
-				{/each}	
+				{/each}
 			</select>
 
 			<select bind:value={$loggerState.level}>

--- a/cockpit/src/lib/components/logger/Loggers.svelte
+++ b/cockpit/src/lib/components/logger/Loggers.svelte
@@ -1,17 +1,27 @@
 <script lang="ts">
 	import Container from '$lib/components/Container.svelte';
 	import { loggerState, tabs } from '$lib/logger';
+	import { LogLevel, logLevelLabel } from '$lib/process-logger';
 </script>
 
 <Container noPadding>
 	<div class="header" slot="header">
 		<h3>{tabs[$loggerState.selectedTabId].name}</h3>
 
-		<select bind:value={$loggerState.selectedTabId}>
-			{#each Object.keys(tabs) as tabId}
-				<option value={tabId}>{tabs[tabId].name}</option>
-			{/each}
-		</select>
+		<div>
+			<select bind:value={$loggerState.selectedTabId}>
+				{#each Object.keys(tabs) as tabId}
+					<option value={tabId}>{tabs[tabId].name}</option>
+				{/each}	
+			</select>
+
+			<select bind:value={$loggerState.level}>
+				<option value={LogLevel.ERROR}>{logLevelLabel(LogLevel.ERROR)}</option>
+				<option value={LogLevel.WARN}>{logLevelLabel(LogLevel.WARN)}</option>
+				<option value={LogLevel.INFO}>{logLevelLabel(LogLevel.INFO)}</option>
+				<option value={LogLevel.DEBUG}>{logLevelLabel(LogLevel.DEBUG)}</option>
+			</select>
+		</div>
 	</div>
 
 	<div class="output">

--- a/cockpit/src/lib/logger.ts
+++ b/cockpit/src/lib/logger.ts
@@ -4,6 +4,7 @@ import { writable } from 'svelte/store';
 import LinkageLoggerOutput from '$lib/components/logger/LinkageLoggerOutput.svelte';
 import CockpitBackendLoggerOutput from '$lib/components/logger/CockpitBackendLoggerOutput.svelte';
 import CarburetorLoggerOutput from '$lib/components/logger/CarburetorLoggerOutput.svelte';
+import { LogLevel } from '$lib/process-logger';
 
 export interface Tab {
 	name: string;
@@ -29,8 +30,10 @@ export type TabId = keyof typeof tabs;
 
 export interface LoggerState {
 	selectedTabId: TabId;
+	level: LogLevel;
 }
 
 export const loggerState = writable<LoggerState>({
-	selectedTabId: 'cockpit-backend'
+	selectedTabId: 'cockpit-backend',
+	level: LogLevel.DEBUG
 });

--- a/cockpit/src/lib/process-logger.ts
+++ b/cockpit/src/lib/process-logger.ts
@@ -26,7 +26,7 @@ export enum LogLevel {
 	 * The "debug" level.
 	 * Designates lower priority information.
 	 */
-	DEBUG,
+	DEBUG
 }
 
 export function logLevelLabel(level: LogLevel) {

--- a/cockpit/src/lib/process-logger.ts
+++ b/cockpit/src/lib/process-logger.ts
@@ -27,11 +27,6 @@ export enum LogLevel {
 	 * Designates lower priority information.
 	 */
 	DEBUG,
-	/**
-	 * The "trace" level.
-	 * Designates very low priority, often extremely verbose, information.
-	 */
-	TRACE
 }
 
 export function logLevelLabel(level: LogLevel) {
@@ -44,8 +39,6 @@ export function logLevelLabel(level: LogLevel) {
 			return 'Info';
 		case LogLevel.DEBUG:
 			return 'Debug';
-		case LogLevel.TRACE:
-			return 'Trace';
 	}
 }
 


### PR DESCRIPTION
This PR implements a new dropdown selector next to the logger selector so you can specify which level of logging you want to show.
closes #62