### PR TITLE
Kill Linkage-lib on Cockpit reload

### DIFF
--- a/cockpit/src-tauri/src/commands/linkage_lib.rs
+++ b/cockpit/src-tauri/src/commands/linkage_lib.rs
@@ -92,13 +92,6 @@ pub fn enable<R: Runtime>(
     Ok(())
 }
 
-#[tauri::command]
-pub fn disable(state: tauri::State<'_, LinkageLibState>) {
-    log::debug!("Received disable command");
-
-    state.disabled.store(true, Ordering::Relaxed);
-}
-
 fn start_linkage_lib_communication(
     config: Config,
     mut gamepad_event_bus_rx: BusReader<Option<CockpitToLinkage>>,
@@ -169,4 +162,11 @@ fn block_until_disable(socket: &mut TcpStream, disabled: Arc<AtomicBool>) {
             _ => {}
         }
     }
+}
+
+#[tauri::command]
+pub fn disable(state: tauri::State<'_, LinkageLibState>) {
+    log::debug!("Received disable command");
+
+    state.disabled.store(true, Ordering::Relaxed);
 }

--- a/cockpit/src-tauri/src/commands/linkage_lib.rs
+++ b/cockpit/src-tauri/src/commands/linkage_lib.rs
@@ -160,7 +160,7 @@ fn block_until_disable(socket: &mut TcpStream, disabled: Arc<AtomicBool>) {
 
         // Didn't receive a disable message from the frontend,
         // so let's see if the connection has been closed.
-        match socket.read_exact(&mut [0]) {
+        match socket.read_exact(&mut [0; 1024]) {
             Err(err) if err.kind() == ErrorKind::UnexpectedEof => {
                 // The socket has been closed.
                 log::debug!("Closing Linkage socket: Linkage socket received UnexpectedEof");

--- a/cockpit/src/App.svelte
+++ b/cockpit/src/App.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { disableRobotCode } from '$lib/backend';
+	import { disableRobotCode, initializeListeners } from '$lib/backend';
 	import Sidebar from '$lib/components/Sidebar.svelte';
 	import type { LoggerTab } from '$lib/logger';
 
@@ -12,6 +12,8 @@
 			disableRobotCode();
 		}
 	});
+
+	initializeListeners();
 </script>
 
 <main>

--- a/cockpit/src/App.svelte
+++ b/cockpit/src/App.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
 	import { disableRobotCode, initializeListeners } from '$lib/backend';
 	import Sidebar from '$lib/components/Sidebar.svelte';
-	import type { LoggerTab } from '$lib/logger';
+	import type { Tab } from '$lib/types/tab';
 
-	let selectedTab: LoggerTab;
+	let selectedTab: Tab;
 
 	const entries = performance.getEntriesByType('navigation');
-	entries.forEach(entry => {
+	entries.forEach((entry: PerformanceNavigationTiming) => {
 		if (entry.type === 'reload') {
 			console.log(`${entry.name} was reloaded. Disabling robot code.`);
 			disableRobotCode();

--- a/cockpit/src/App.svelte
+++ b/cockpit/src/App.svelte
@@ -1,8 +1,17 @@
 <script lang="ts">
+	import { disableRobotCode } from '$lib/backend';
 	import Sidebar from '$lib/components/Sidebar.svelte';
 	import type { LoggerTab } from '$lib/logger';
 
 	let selectedTab: LoggerTab;
+
+	const entries = performance.getEntriesByType('navigation');
+	entries.forEach(entry => {
+		if (entry.type === 'reload') {
+			console.log(`${entry.name} was reloaded. Disabling robot code.`);
+			disableRobotCode();
+		}
+	});
 </script>
 
 <main>

--- a/cockpit/src/lib/backend.ts
+++ b/cockpit/src/lib/backend.ts
@@ -111,7 +111,8 @@ export const gamepadState = writable<GamepadState>(
 
 export async function enableRobotCode() {
 	robotCode.update($robotCode => {
-		$robotCode.changingState = true;
+		if (!$robotCode.enabled)
+			$robotCode.changingState = true;
 		return $robotCode;
 	});
 	return invoke('enable');
@@ -119,7 +120,8 @@ export async function enableRobotCode() {
 
 export async function disableRobotCode() {
 	robotCode.update($robotCode => {
-		$robotCode.changingState = true;
+		if ($robotCode.enabled)
+			$robotCode.changingState = true;
 		return $robotCode;
 	});
 	return invoke('disable');

--- a/cockpit/src/lib/backend.ts
+++ b/cockpit/src/lib/backend.ts
@@ -1,4 +1,4 @@
-import { get, writable } from 'svelte/store';
+import { writable } from 'svelte/store';
 import type { SystemInfo } from '$lib/types/system-info';
 import { listen } from '@tauri-apps/api/event';
 import { loggerState } from '$lib/logger';
@@ -10,9 +10,99 @@ import {
 	parseGamepadInputEvent
 } from '$lib/gamepad-data';
 
-export const systemInfo = writable<SystemInfo | undefined>(
-	undefined,
-	$systemInfo => {
+export const systemInfo = writable<SystemInfo | undefined>(undefined);
+
+export interface RobotCodeState {
+	enabled: boolean;
+	changingState: boolean;
+}
+
+export const robotCode = writable<RobotCodeState>({
+	enabled: false,
+	changingState: false
+});
+
+export interface GamepadState {
+	gamepads: { [id: GamepadId]: GamepadData };
+}
+
+export const gamepadState = writable<GamepadState>({
+	gamepads: {}
+});
+
+export async function enableRobotCode() {
+	robotCode.update($robotCode => {
+		if (!$robotCode.enabled)
+			$robotCode.changingState = true;
+		return $robotCode;
+	});
+	return invoke('enable');
+}
+
+export async function disableRobotCode() {
+	robotCode.update($robotCode => {
+		if ($robotCode.enabled)
+			$robotCode.changingState = true;
+		return $robotCode;
+	});
+	return invoke('disable');
+}
+
+export function initializeListeners() {
+	initializeSystemInfoListener();
+	initializeGamepadEventListener();
+	initializeLinkageLibStateListener();
+}
+
+function initializeLinkageLibStateListener() {
+	listen('linkage_lib_state_change', event => {
+		robotCode.update($robotCode => {
+			$robotCode.changingState = false;
+			if (event.payload === 'Enabled') {
+				$robotCode.enabled = true;
+				loggerState.update($loggerState => {
+					$loggerState.selectedTabId = 'linkage';
+					return $loggerState;
+				});
+			} else if (event.payload === 'Disabled') {
+				$robotCode.enabled = false;
+				loggerState.update($loggerState => {
+					$loggerState.selectedTabId = 'cockpit-backend';
+					return $loggerState;
+				});
+			}
+
+			return $robotCode;
+		});
+	});
+}
+
+function initializeGamepadEventListener() {
+	invoke('start_event_listener').then(() => {
+		listen('gamepad_event', event => {
+			gamepadState.update($gamepadState => {
+				const gamepadInputEvent = parseGamepadInputEvent(event.payload);
+				if (!gamepadInputEvent) return;
+
+				if (gamepadInputEvent.eventType === EventType.DISCONNECTED) {
+					delete $gamepadState.gamepads[gamepadInputEvent.gamepadId];
+				} else {
+					if (!$gamepadState.gamepads[gamepadInputEvent.gamepadId])
+						$gamepadState.gamepads[gamepadInputEvent.gamepadId] =
+							new GamepadData(gamepadInputEvent.gamepadId);
+					$gamepadState.gamepads[
+						gamepadInputEvent.gamepadId
+					].handleGamepadInputEvent(gamepadInputEvent);
+				}
+
+				return $gamepadState;
+			});
+		});
+	});
+}
+
+function initializeSystemInfoListener() {
+	systemInfo.update($systemInfo => {
 		// TODO: Check periodically if we have a connection with the robot.
 		//  	 Currently you have to reload the app to
 		//       Connect after a restart of the robot.
@@ -41,88 +131,7 @@ export const systemInfo = writable<SystemInfo | undefined>(
 			.catch(error => {
 				console.error('Could connect to Gauge: ' + error);
 			});
-	}
-);
 
-export interface RobotCodeState {
-	enabled: boolean;
-	changingState: boolean;
-}
-
-export const robotCode = writable<RobotCodeState>(
-	{
-		enabled: false,
-		changingState: false
-	},
-	() => {
-		listen('linkage_lib_state_change', event => {
-			robotCode.update($robotCode => {
-				$robotCode.changingState = false;
-				if (event.payload === 'Enabled') {
-					$robotCode.enabled = true;
-					loggerState.update($loggerState => {
-						$loggerState.selectedTabId = 'linkage';
-						return $loggerState;
-					});
-				} else if (event.payload === 'Disabled') {
-					$robotCode.enabled = false;
-					loggerState.update($loggerState => {
-						$loggerState.selectedTabId = 'cockpit-backend';
-						return $loggerState;
-					});
-				}
-
-				return $robotCode;
-			});
-		});
-	}
-);
-
-export interface GamepadState {
-	gamepads: { [id: GamepadId]: GamepadData };
-}
-
-export const gamepadState = writable<GamepadState>(
-	{
-		gamepads: {}
-	},
-	set => {
-		invoke('start_event_listener').then(() => {
-			listen('gamepad_event', event => {
-				const gamepadInputEvent = parseGamepadInputEvent(event.payload);
-				if (!gamepadInputEvent) return;
-
-				const state = get(gamepadState);
-				if (gamepadInputEvent.eventType === EventType.DISCONNECTED) {
-					delete state.gamepads[gamepadInputEvent.gamepadId];
-				} else {
-					if (!state.gamepads[gamepadInputEvent.gamepadId])
-						state.gamepads[gamepadInputEvent.gamepadId] =
-							new GamepadData(gamepadInputEvent.gamepadId);
-					state.gamepads[
-						gamepadInputEvent.gamepadId
-					].handleGamepadInputEvent(gamepadInputEvent);
-				}
-				set(state);
-			});
-		});
-	}
-);
-
-export async function enableRobotCode() {
-	robotCode.update($robotCode => {
-		if (!$robotCode.enabled)
-			$robotCode.changingState = true;
-		return $robotCode;
+		return $systemInfo;
 	});
-	return invoke('enable');
-}
-
-export async function disableRobotCode() {
-	robotCode.update($robotCode => {
-		if ($robotCode.enabled)
-			$robotCode.changingState = true;
-		return $robotCode;
-	});
-	return invoke('disable');
 }

--- a/cockpit/src/lib/types/tab.d.ts
+++ b/cockpit/src/lib/types/tab.d.ts
@@ -1,7 +1,7 @@
-import { SvelteComponent } from 'svelte';
+import { SvelteComponentTyped } from 'svelte';
 
 interface Tab {
 	label: string;
-	component: SvelteComponent;
-	iconComponent: SvelteComponent;
+	component: SvelteComponentTyped;
+	iconComponent: SvelteComponentTyped;
 }


### PR DESCRIPTION
If you reload the Cockpit window with the context menu, you are still able to send gamepad input to the robot code, indicating the robot code still is running. This shouldn't be the case.